### PR TITLE
Newgraph

### DIFF
--- a/client/components/GraphDataset.jsx
+++ b/client/components/GraphDataset.jsx
@@ -42,7 +42,9 @@ class GraphDataset extends Component {
   handleGraphClick(graphType) {
     const {dataset, graphSettings} = this.props
     const {currentX, currentY} = graphSettings
-    const {datasetName} = dataset
+    const datasetName = dataset.name
+    //if the dataset already has an aws then we want to make that the awsId
+    //this will cause use to reuse that dataset for the graph
     const awsId = crypto
       .randomBytes(8)
       .toString('base64')
@@ -56,6 +58,7 @@ class GraphDataset extends Component {
     console.log('graphId', graphId)
   
      //Upload dataset to S3 AWS
+     //if the dataset already has an awsId we need to not do this
     let AWSPost = axios.post(`api/graphs/aws/${awsId}`, {
       dataset
     })

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset='utf-8'>
     <meta name='viewport' content='width=device-width initial-scale=1.0'>
-    <title>Boilermaker</title>
+    <title>Graphify</title>
     <link rel="stylesheet" href="https://unpkg.com/react-table@latest/react-table.css">
     <link rel="stylesheet" href="/style.css" />
     <script defer src="/bundle.js"></script>

--- a/server/api/graphs.js
+++ b/server/api/graphs.js
@@ -51,16 +51,14 @@ router.post('/:graphId', (req, res, next) => {
     let makingDataset = Dataset.findOrCreate({
       where : {
         name: datasetName,
-        userId
-      },
-      default: {
+        userId,
         awsId
       }
     })
     return Promise.all([makingGraph, makingYAxes, makingDataset])
       .then(([newGraph, newYAxes, newDataset]) => {
         let setY = newGraph.setYAxes(newYAxes)
-        let setDataset = newGraph.setDataset(newDataset)
+        let setDataset = newGraph.setDataset(newDataset[0])
         return Promise.all([setY, setDataset])
       })
       .then(() => res.send('worked'))

--- a/server/api/graphs.js
+++ b/server/api/graphs.js
@@ -48,10 +48,14 @@ router.post('/:graphId', (req, res, next) => {
         return YAxis.create({name})
       })
     )
-    let makingDataset = Dataset.create({
-      awsId,
-      name: datasetName,
-      userId
+    let makingDataset = Dataset.findOrCreate({
+      where : {
+        name: datasetName,
+        userId
+      },
+      default: {
+        awsId
+      }
     })
     return Promise.all([makingGraph, makingYAxes, makingDataset])
       .then(([newGraph, newYAxes, newDataset]) => {
@@ -76,7 +80,7 @@ router.put('/:graphId', (req, res, next) => {
       where: {
         graphId
       },
-      include: [{model: YAxis, model: Dataset}]
+      include: [{model: YAxis}]
     })
       //update the found graph
       .then(foundGraph => {


### PR DESCRIPTION
In database the dataset will be found or created, so we don't make new copies for a dataset.

This is not yet fixed in the front end, we need to have the already used awsId sent if the dataset already has one
