### PR TITLE
Aws route

### DIFF
--- a/client/components/GraphDataset.jsx
+++ b/client/components/GraphDataset.jsx
@@ -45,6 +45,8 @@ class GraphDataset extends Component {
     const datasetName = dataset.name
     //if the dataset already has an aws then we want to make that the awsId
     //this will cause use to reuse that dataset for the graph
+
+    //DELETE THESE CONSOLE LOGS IN FUTURE, useful for testing now
     const awsId = crypto
       .randomBytes(8)
       .toString('base64')
@@ -59,9 +61,7 @@ class GraphDataset extends Component {
   
      //Upload dataset to S3 AWS
      //if the dataset already has an awsId we need to not do this
-    let AWSPost = axios.post(`api/graphs/aws/${awsId}`, {
-      dataset
-    })
+    let AWSPost = axios.post(`api/graphs/aws/${awsId}`, {dataset})
     let databasePost = axios.post(`api/graphs/${graphId}`, {
       xAxis: currentX,
       yAxis: currentY,
@@ -72,7 +72,6 @@ class GraphDataset extends Component {
     })
     Promise.all([AWSPost, databasePost])
       .then(() => {
-        console.log("S3, GRAPH CREATED")
         this.props.history.push(`/graph-dataset/customize/${graphId}`)
       })
       .catch(console.error)
@@ -86,7 +85,7 @@ class GraphDataset extends Component {
       handleYCategory
     } = this.props
     const { currentX, currentY } = graphSettings
-    const columnObj = dataset.length > 0 ? dataset.columnObj : {}
+    const columnObj = dataset.dataset.length > 0 ? dataset.columnObj : {}
     const xAxis = Object.keys(columnObj)
     const yAxis = xAxis.filter(key => {
       return (
@@ -104,11 +103,11 @@ class GraphDataset extends Component {
     return (
       <div className="graphContainer">
         <h1>{dataset.name}</h1>
-        {dataset.length &&
+        {dataset.dataset.length &&
           xAxis.length && (
             <div>
               <ReactTable
-                data={dataset}
+                data={dataset.dataset}
                 columns={columns}
                 defaultPageSize={5}
               />
@@ -116,7 +115,7 @@ class GraphDataset extends Component {
           )}
 
         <h1>Select the Data to Graph</h1>
-        {dataset.length && (
+        {dataset.dataset.length && (
           <div>
             <div>
               <div>

--- a/client/components/GraphDataset.jsx
+++ b/client/components/GraphDataset.jsx
@@ -47,21 +47,25 @@ class GraphDataset extends Component {
     //this will cause use to reuse that dataset for the graph
 
     //DELETE THESE CONSOLE LOGS IN FUTURE, useful for testing now
-    const awsId = crypto
+    //awsId will equal a new id or the one that the dataset already has
+    const awsId = !!dataset.awsId ? dataset.awsId :  
+    crypto
       .randomBytes(8)
       .toString('base64')
-      .replace(/\//g, '7')
+      .replace(/\//g, '7');
     console.log('awsId', awsId)
 
     const graphId = crypto
       .randomBytes(8)
       .toString('base64')
-      .replace(/\//g, '7')
+      .replace(/\//g, '7');
     console.log('graphId', graphId)
   
-     //Upload dataset to S3 AWS
-     //if the dataset already has an awsId we need to not do this
-    let AWSPost = axios.post(`api/graphs/aws/${awsId}`, {dataset})
+    //upload to AWS only if the dataset doesn't already have an awsId
+    let AWSPost = !dataset.awsId ? 
+    axios.post(`api/graphs/aws/${awsId}`, {dataset}) :
+    AWSPost = Promise.resolve();
+
     let databasePost = axios.post(`api/graphs/${graphId}`, {
       xAxis: currentX,
       yAxis: currentY,

--- a/client/components/SingleGraphView.jsx
+++ b/client/components/SingleGraphView.jsx
@@ -18,7 +18,7 @@ import {
   fetchAndSetDataFromS3
 } from '../store'
 import {HuePicker} from 'react-color'
-// import * from '../public/style.css'
+
 
 class SingleGraphView extends Component {
   constructor(props) {
@@ -35,8 +35,6 @@ class SingleGraphView extends Component {
     const {graphId} = this.props.match.params
     const {getGraphId} = this.props
     getGraphId(graphId)
-    // const {awsId} = this.props.graphSettings
-    // getDataset(awsId)
   }
 
   handleChange(event) {
@@ -53,7 +51,6 @@ class SingleGraphView extends Component {
   }
 
   handleClick(idx) {
-    console.log('index', idx)
     this.setState({legend: idx})
   }
 

--- a/client/components/graphs/AreaChartGraph.jsx
+++ b/client/components/graphs/AreaChartGraph.jsx
@@ -17,7 +17,7 @@ export const AreaChartGraph = props => {
   return (
     <div>
       <h4>{title}</h4>
-      <AreaChart width={600} height={600} data={dataset}>
+      <AreaChart width={600} height={600} data={dataset.dataset}>
         <CartesianGrid strokeDasharray="3 3" />
         <XAxis dataKey={currentX} label={{value:`${xAxisName}`, offset:-20, position:"insideBottom"}} />
         <YAxis label={{value:`${yAxisName}`, angle:-90, position:"insideLeft"}} />

--- a/client/components/graphs/BarChartGraph.jsx
+++ b/client/components/graphs/BarChartGraph.jsx
@@ -19,7 +19,7 @@ export const BarChartGraph = props => {
   return (
     <div>
       <h4>{title}</h4>
-      <BarChart width={600} height={600} data={dataset}>
+      <BarChart width={600} height={600} data={dataset.dataset}>
         <CartesianGrid strokeDasharray="3 3" />
         {
           currentX.toLowerCase() !== 'number' ?

--- a/client/components/graphs/LineChartGraph.jsx
+++ b/client/components/graphs/LineChartGraph.jsx
@@ -18,7 +18,7 @@ export const LineChartGraph = props => {
   return (
     <div>
       <h4>{title}</h4>
-      <LineChart width={600} height={600} data={dataset}>
+      <LineChart width={600} height={600} data={dataset.dataset}>
         {currentY.length && currentY.map((yAxis, idx) => (
           <Line key={idx} type="monotone" dataKey={yAxis} stroke={colors[idx]} />
         ))}

--- a/client/components/graphs/PieChartGraph.jsx
+++ b/client/components/graphs/PieChartGraph.jsx
@@ -33,7 +33,7 @@ export const PieChartGraph = props => {
       <PieChart width={600} height={600}>
         <Pie
           isAnimationActive={true}
-          data={quantityMaker(dataset, currentX)}
+          data={quantityMaker(dataset.dataset, currentX)}
           dataKey="value"
           cx={200}
           cy={200}
@@ -44,7 +44,7 @@ export const PieChartGraph = props => {
           <Pie
             key={idx}
             isAnimationActive={true}
-            data={quantityMaker(dataset, yAxis)}
+            data={quantityMaker(dataset.dataset, yAxis)}
             dataKey="value"
             cx={200}
             cy={200}

--- a/client/components/graphs/RadarChartGraph.jsx
+++ b/client/components/graphs/RadarChartGraph.jsx
@@ -23,7 +23,7 @@ export const RadarChartGraph = props => {
         outerRadius={250}
         width={600}
         height={600}
-        data={dataset}
+        data={dataset.dataset}
       >
         <Tooltip />
         <Legend align='right'/>

--- a/client/components/graphs/ScatterChartGraph.jsx
+++ b/client/components/graphs/ScatterChartGraph.jsx
@@ -26,7 +26,7 @@ export const ScatterChartGraph = props => {
         <Tooltip cursor={{strokeDasharray: '3 3'}} />
         <Legend align='right'/>
         {currentY.length && currentY.map((yAxis, idx) =>(
-          <Scatter yAxisId={idx} key={idx} name={yAxis} data={dataset} fill={colors[idx]} />
+          <Scatter yAxisId={idx} key={idx} name={yAxis} data={dataset.dataset} fill={colors[idx]} />
         ))}
       </ScatterChart>
     </div>

--- a/client/store/dataset.js
+++ b/client/store/dataset.js
@@ -14,7 +14,11 @@ const SET_DATA = 'SET_DATA'
 /**
  * INITIAL STATE
  */
-const defaultData = []
+const defaultData = {
+  dataset: [],
+  columnObj: {},
+  name: '' 
+}
 
 /**
  * ACTION CREATORS
@@ -31,12 +35,7 @@ export const uploadData = (data, fileName) => dispatch => {
   history.push('/graph-dataset')
 }
 
-export const getAsyncData = (
-  domain,
-  id,
-  columnObj,
-  datasetName
-) => dispatch => {
+export const getAsyncData = (domain, id, columnObj, datasetName) => dispatch => {
   return d3
     .csv(`https://${domain}/resource/${id}.csv`)
     .then(res => {

--- a/client/store/graphSettings.js
+++ b/client/store/graphSettings.js
@@ -57,7 +57,7 @@ export const fetchAndSetGraph = graphId => dispatch => {
     .get(`/api/graphs/${graphId}`)
     .then(res => {
       dispatch(fetchAndSetGraphFromDatabase(res.data.graph));
-      dispatch(setData(res.data.dataset));
+      dispatch(setData(res.data.dataset.dataset));
     })
     .catch(err => console.log(err))
 }
@@ -94,7 +94,6 @@ export default (state = graphSettings, action) => {
       })
       return {...state, colors: newColors}
     case FETCH_AND_SET_GRAPH:
-      console.log('GRAPHSETTINGS', action.graph)
       const {xAxis, yAxes, graphType} = action.graph
       const YAxisNames = yAxes.map(yAxis => yAxis.name)
       return {...state, currentX: xAxis, currentY: YAxisNames, graphType}

--- a/client/store/utils/datasetOrganizingFuncs.js
+++ b/client/store/utils/datasetOrganizingFuncs.js
@@ -12,8 +12,7 @@ export function datasetColumnFormatter(dataset, columnObj) {
         }
     }
     //add the columnObj onto the dataset
-    dataset.columnObj = columnObj;
-    return dataset;
+    return {dataset, columnObj}
 }
 
 //change uploaded data from array of arrays into an array of objects

--- a/server/api/aws.js
+++ b/server/api/aws.js
@@ -1,0 +1,29 @@
+const router = require('express').Router();
+const {Graph, YAxis, Dataset} = require('../db/models')
+const {AWS_KEY, AWS_SECRET, AWS_BUCKET} = require('../../secrets')
+const AWS = require('aws-sdk')
+// set all the keys and region here
+AWS.config.update({
+  accessKeyId: AWS_KEY,
+  secretAccessKey: AWS_SECRET,
+  region: 'us-east-2'
+})
+
+module.exports = router;
+
+router.get('/:awsId', (req, res, next) => {
+    //have some kind of security so that we don't do this if the user doesn't have access to the graph
+    const {awsId} = req.params
+    let datasetParams = {Bucket: AWS_BUCKET, Key: awsId}
+    //this makes the promise to do the actual request, get object is a get request
+    let findDatasetPromise = new AWS.S3({apiVersion: '2006-03-01'})
+    .getObject(datasetParams)
+    .promise()
+    findDatasetPromise
+    .then(result => {
+        let parsedDataset = JSON.parse(result.Body)
+        parsedDataset.awsId = awsId;
+        res.json(parsedDataset)
+    })
+    .catch(next)
+})

--- a/server/api/graphs.js
+++ b/server/api/graphs.js
@@ -83,11 +83,7 @@ router.put('/:graphId', (req, res, next) => {
       //update the found graph
       .then(foundGraph => {
         let effectedGraph = foundGraph.update({
-          xAxis,
-          xAxisLabel,
-          yAxisLabel,
-          title,
-          graphType
+          xAxis, xAxisLabel, yAxisLabel, title, graphType
         })
         //destroy the current yAxes
         foundGraph.yAxes.map(yAxis => {
@@ -134,8 +130,8 @@ router.get('/aws/:awsId', (req, res, next) => {
 router.post('/aws/:awsId', (req, res, next) => {
   if (req.user) {
     const {awsId} = req.params
-    const {dataset} = req.body
-    const stringifiedDataset = JSON.stringify(dataset)
+    const {dataset, columnObj} = req.body
+    const stringifiedDataset = JSON.stringify({dataset, columnObj})
     let datasetParams = {
       Bucket: AWS_BUCKET,
       Key: awsId,

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -4,6 +4,7 @@ module.exports = router
 router.use('/users', require('./users'))
 router.use('/soda', require('./soda'))
 router.use('/graphs', require('./graphs'))
+router.use('/aws', require('./aws'))
 
 router.use((req, res, next) => {
   const error = new Error('Not Found')


### PR DESCRIPTION
Changed dataset store to be an object with three things dataset, columnObj and name. AWS was not saving the colmunObj and name when we sent it as an array, so we couldn't reuse them for new graphs. Could cause many issues when using the dataset, (issues with array methods).

Also made a new route for getting the dataset from aws
/api/aws/:awsId
which will attach the awsID so we can use that to not recreate the same dataset in AWS


